### PR TITLE
W3MMD: Stick to a single player search algorithm on init pid

### DIFF
--- a/src/w3g/Model/ChatMessage.php
+++ b/src/w3g/Model/ChatMessage.php
@@ -25,7 +25,7 @@ class ChatMessage extends Model
 
         $this->flags    = $block->int8 ();
         $this->mode     = $block->uint32 ();
-        $this->message  = $block->string ();
+        $this->message  = utf8_encode($block->string ());
 
         $this->time     = Context::getTime ();
     }

--- a/src/w3g/Model/W3MMD.php
+++ b/src/w3g/Model/W3MMD.php
@@ -150,7 +150,7 @@ class W3MMD extends Model
                         $player = Context::$replay->getPlayerByName ($this->playerName);
 
                         if (!$player) {
-                           $player = Context::$replay->getPlayerByOrder ($this->playerId);
+                           break;
                         }
 
                         self::$pids [$this->playerId] = $player->id;


### PR DESCRIPTION
This commit is a stopgap fix to deal with the worst symptoms described in #1 (by cutting off the unexpected bits of data, MMR is no longer updated.)

Searching player name is preferred because:
- pids are initialized very eagerly in W3MMD implementations, so names are guaranteed to be correct.
- pids in W3MMD spec refers to player ID, as in the result of the JASS call ``GetPlayerId(player)``. That value does not match the player IDs parsed by this library's game/replay modules.